### PR TITLE
Use INTEGER NOT NULL to follow crecto example

### DIFF
--- a/db/migrations/20231222134745_create_pastes.sql
+++ b/db/migrations/20231222134745_create_pastes.sql
@@ -1,7 +1,7 @@
 -- +micrate Up
 -- SQL in section 'Up' is executed when this migration is applied
 CREATE TABLE IF NOT EXISTS pastes (
-    id BIGSERIAL PRIMARY KEY,
+    id INTEGER NOT NULL PRIMARY KEY,
     sha256 TEXT UNIQUE NOT NULL,
     ext TEXT NOT NULL,
     mime TEXT NOT NULL,


### PR DESCRIPTION
From the crecto spec, they use INTEGER NOT NULL for the id, and this change fixes #1.